### PR TITLE
Change branch structure

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,7 @@
 name: Build plugin on Pull Request
 on:
   pull_request:
-    branches: [devel, master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,5 @@
 name: Generate release (Pypi, tag, & GitHub Release)
-on:
-  push:
-    branches: [ master ]
+on: workflow_dispatch
 
 jobs:
   deploy:


### PR DESCRIPTION
- Only `main` as long-lived branch
- Deployment workflows are run on demand, not on push