### PR TITLE
Test conda

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,9 +37,6 @@ jobs:
         pip install --user scipion-installer
         python3 -m scipioninstaller -conda -noAsk scipion
     
-    - name: Test conda
-      run: conda info --envs
-    
     - name: Checkout repository
       uses: actions/checkout@main
       with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,6 +37,9 @@ jobs:
         pip install --user scipion-installer
         python3 -m scipioninstaller -conda -noXmipp -noAsk scipion
     
+    - name: Test conda
+      run: conda info --envs
+    
     - name: Checkout repository
       uses: actions/checkout@main
       with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         pip cache purge
         pip install --user scipion-installer
-        python3 -m scipioninstaller -conda -noXmipp -noAsk scipion
+        python3 -m scipioninstaller -conda -noAsk scipion
     
     - name: Test conda
       run: conda info --envs


### PR DESCRIPTION
The new Scipion release deletes this flag, so it instead gets mistaken as a conda flag `-n oXmipp`, creating an env called `oXmipp`.